### PR TITLE
chore: add Serena project memories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,6 @@ playwright-report/
 test-results/
 e2e/screenshots/*
 !e2e/screenshots/.gitkeep
+
+# Local git worktrees
+.worktrees/

--- a/.serena/.gitignore
+++ b/.serena/.gitignore
@@ -1,0 +1,2 @@
+/cache
+/project.local.yml

--- a/.serena/memories/code_style_and_conventions.md
+++ b/.serena/memories/code_style_and_conventions.md
@@ -1,0 +1,61 @@
+# Code Style & Conventions — UnitTestInterface
+
+## PHP
+- **PHP >= 8.1** (procedural with classes; no build step)
+- **PSR-12** with custom rules, **line length 200** (config: `phpcs.xml`)
+- PSR-4: `LiturgicalCalendar\UnitTestInterface\` → `src/`
+- Auto-fix style with `composer lint:fix`
+
+## JavaScript
+- **Native ES6** (DOM, fetch, WebSocket)
+- **No jQuery** despite README mention — Bootstrap 5 native JS API (Toast, Collapse, Modal, Tooltip) is used directly
+- Shared utilities live in `assets/js/common.js`:
+  - `escapeHtmlAttr(s)`
+  - `slugify(s)`
+  - `slugifySelector(sel)` — required to translate server-side selectors (original casing) into client-side card class names (slugified). **Always use this** when querying for cards based on `response.classes`.
+
+## CSS class slugification (CRITICAL)
+Server emits selectors like `.MaryMotherChurchTest`; client cards are created with `.marymotherchurchtest`. Without `slugifySelector()`, DOM updates will silently miss.
+
+```javascript
+document.querySelectorAll(slugifySelector(responseData.classes)).forEach(el => { /* … */ });
+```
+
+## WebSocket categories (CRITICAL)
+- For **all** source-data validations, use `category: "sourceDataCheck"` (NOT `nationalcalendar` / `widerregioncalendar` / `diocesancalendar`)
+- The server uses regex on the `validate` field to compute file paths
+- For missals, convert `missal_id` to `proprium-de-sanctis-…` form (see project_structure memory)
+
+## API date handling
+- RFC 3339, midnight UTC: `"2018-05-21T00:00:00+00:00"`
+- Parse with `new Date(str)`
+- Display with `Intl.DateTimeFormat(locale, { timeZone: 'UTC', … })`
+
+## Globals exposed from PHP → JS
+- `locale` — for `Intl.DateTimeFormat`
+- `LitcalEvents` — events array from API
+
+## i18n (gettext)
+- Translation files under `i18n/{locale}/LC_MESSAGES/`
+- 10+ languages supported: en (default), de, es, fr, hr, hu, it, pl, pt, sk
+- Use `_()` for translatable strings; `pgettext.php` for context-aware translations
+- Locale detection in `includes/I18n.php`
+
+## Markdown
+- `.markdownlint.yml`:
+  - Max line length **180** (excl. code blocks, tables)
+  - MD060: tables vertically aligned
+  - Fenced code blocks with language specifier
+
+## Auth
+- HTTP Basic Auth on all pages via `includes/auth.php`
+- Credentials loaded from `credentials.php` (gitignored)
+- Use `password_verify()` against hashed values
+
+## Liturgical timezone
+Always `Europe/Vatican` for any liturgical date math (matches API).
+
+## Naming conventions
+- PHP: PascalCase classes/namespaces, camelCase methods/properties, snake_case for procedural helpers in older code
+- JS: camelCase functions/vars, PascalCase classes (e.g. `AssertionsBuilder`, `Assertion`)
+- File names: kebab-case for top-level pages where present; single-word `.php` for root entry points

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -1,0 +1,44 @@
+# UnitTestInterface — Project Overview
+
+**Web-based graphical test interface** for validating the LiturgicalCalendarAPI. Connects via **WebSocket** to a test server (the API's `Health.php` Ratchet websocket), runs unit tests asynchronously, and renders results in real time on a responsive Bootstrap 5 dashboard.
+
+## Testing capabilities
+- Source data validation against JSON schemas
+- Calendar generation across locales / regions
+- API response formats (JSON, YAML, XML, ICS)
+- Liturgical event definitions and precedence rules
+
+## Tech Stack
+- **PHP >= 8.1** (procedural with classes; **no build step**)
+- Composer package: `liturgical-calendar/unit-test-interface`, namespace `LiturgicalCalendar\UnitTestInterface\` → `src/`
+- Frontend: Native ES6 JS (no jQuery dependency despite README mention), Bootstrap 5 (native JS API: Toast, Collapse, Modal, Tooltip), Font Awesome 7
+- Communication: WebSocket → Ratchet server (`LiturgicalCalendarAPI/src/Health.php`)
+- PHP deps: `liturgical-calendar/components` ^3.1, `firebase/php-jwt`, `guzzlehttp/guzzle`, `monolog/monolog`, `vlucas/phpdotenv`
+- Quality: PHP_CodeSniffer (PSR-12 + custom rules, line length 200)
+- E2E: Playwright + TypeScript (Node, also `bun.lock` present)
+- i18n: GNU gettext, 10+ languages: en (default), de, es, fr, hr, hu, it, pl, pt, sk
+
+## Live URL
+Production WebSocket endpoint: `wss://litcal-test.johnromanodorazio.com`
+
+## Repo Location
+`/home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface`
+
+## Companion repos
+- `LiturgicalCalendarAPI` — owns the WebSocket server (`src/Health.php`) and source data; this UI cannot work without it
+- `LiturgicalCalendarFrontend` — the public-facing site
+- `liturgy-components-js` — shared JS components
+
+## Default ports (dev)
+- API: `localhost:8000`
+- WebSocket server: `localhost:8082` (CLAUDE.md) / `8080` in some docs (README) — verify against `.env.example`
+- This interface: `localhost:3003`
+
+## Auth
+HTTP Basic Auth on all pages. Credentials in `credentials.php` (gitignored). Verified via `password_verify()`.
+
+## Code review workflow
+**CodeRabbit** runs on PRs with rate-limiting:
+1. Collect all CodeRabbit comments first
+2. Address everything in a batched series of commits
+3. Push only after all local fixes — avoid multiple small pushes

--- a/.serena/memories/project_overview.md
+++ b/.serena/memories/project_overview.md
@@ -22,7 +22,6 @@
 Production WebSocket endpoint: `wss://litcal-test.johnromanodorazio.com`
 
 ## Repo Location
-`/home/johnrdorazio/development/LiturgicalCalendar/UnitTestInterface`
 
 ## Companion repos
 - `LiturgicalCalendarAPI` — owns the WebSocket server (`src/Health.php`) and source data; this UI cannot work without it

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,0 +1,115 @@
+# Codebase Structure — UnitTestInterface
+
+## Top-level layout
+```
+UnitTestInterface/
+├── index.php              # Main test runner UI
+├── admin.php              # Admin interface
+├── resources.php          # Resource testing interface
+├── credentials.php        # HTTP Basic Auth credentials (gitignored)
+├── includes/
+│   ├── I18n.php           # Locale detection + gettext setup
+│   ├── auth.php           # HTTP Basic Auth
+│   └── pgettext.php       # context-aware translation
+├── layout/
+│   ├── head.php           # HTML <head>, CSS/JS includes
+│   ├── topnavbar.php
+│   ├── sidebar.php
+│   └── footer.php
+├── components/
+│   └── NewTestModal.php   # Test creation modal
+├── assets/
+│   ├── js/
+│   │   ├── admin.js
+│   │   ├── AssertionsBuilder.js   # Test assertion builder + enums
+│   │   ├── common.js              # Shared utilities (escapeHtmlAttr, slugify, slugifySelector…)
+│   │   ├── index.js               # Main test runner / WebSocket client
+│   │   └── resources.js
+│   └── css/
+├── i18n/                   # gettext translations: i18n/{locale}/LC_MESSAGES/
+├── src/                    # PSR-4 root for LiturgicalCalendar\UnitTestInterface\
+├── e2e/                    # Playwright tests + e2e/tsconfig.json
+├── playwright-report/, test-results/   # gitignored Playwright artifacts
+├── logs/                   # runtime logs (gitignored)
+├── vendor/, node_modules/  # deps
+├── .vscode/, .github/      # editor + CI config
+├── composer.json / composer.lock
+├── package.json / bun.lock
+├── playwright.config.ts
+├── phpcs.xml               # PSR-12 + custom rules, line length 200
+├── .markdownlint.yml
+├── .env, .env.example, .env.development
+├── Dockerfile, .dockerignore
+└── CLAUDE.md, README.md, CODE_OF_CONDUCT.md, LICENSE
+```
+
+## Key JS classes / enums (`assets/js/AssertionsBuilder.js`)
+- `TestType` — enum of test kinds (`exactCorrespondence`, `exactCorrespondenceSince`, …)
+- `AssertType` — enum of assertion kinds (`eventNotExists`, `eventExists` AND `hasExpectedDate`)
+- `LitGrade` — enum of liturgical grades (`WEEKDAY` … `HIGHER_SOLEMNITY`)
+- `AssertionsBuilder` — builds HTML for assertion UI
+- `Assertion` — single assertion model
+
+## PHP-defined globals exposed to JS
+- `locale` — for `Intl.DateTimeFormat`
+- `LitcalEvents` — array of liturgical events from API
+
+## WebSocket message protocol
+
+### Required `action` field
+| Action               | Purpose                                          | Required props                                   |
+|----------------------|--------------------------------------------------|--------------------------------------------------|
+| `executeValidation`  | Validate source data files vs schemas            | `category`, `validate`, `sourceFile`             |
+| `validateCalendar`   | Validate generated calendar data                 | `category`, `calendar`, `year`, `responsetype`   |
+| `executeUnitTest`    | Run a specific unit test                         | `category`, `calendar`, `year`, `test`           |
+
+### Source data validation: ALWAYS use `category: "sourceDataCheck"`
+The server (`Health.php`) regex-transforms `validate` strings into file paths:
+- `wider-region-{Region}` → wider region file
+- `national-calendar-{CC}` → national calendar file
+- `diocesan-calendar-{id}` → diocesan calendar file
+
+Examples:
+```javascript
+{ "validate": "wider-region-Europe",                  "sourceFile": "Europe",          "category": "sourceDataCheck" }
+{ "validate": "national-calendar-IT",                 "sourceFile": "IT",              "category": "sourceDataCheck" }
+{ "validate": "diocesan-calendar-roma_lazio_it",      "sourceFile": "roma_lazio_it",   "category": "sourceDataCheck" }
+```
+**Wrong** categories like `widerregioncalendar`/`nationalcalendar`/`diocesancalendar` cause the server to use the raw `sourceFile` as a path → fails.
+
+### Missal (Proprium de Sanctis) validation
+Convert `missal_id` → `validate` string:
+
+| missal_id             | validate format                  |
+|-----------------------|----------------------------------|
+| `IT_1983`             | `proprium-de-sanctis-IT-1983`    |
+| `US_2011`             | `proprium-de-sanctis-US-2011`    |
+| `EDITIO_TYPICA_1970`  | `proprium-de-sanctis-1970`       |
+| `EDITIO_TYPICA_2002`  | `proprium-de-sanctis-2002`       |
+
+```javascript
+const parts = missal_id.split('_');
+let validateStr;
+if (parts.length === 2 && /^[A-Z]{2}$/.test(parts[0])) {
+    validateStr = `proprium-de-sanctis-${parts[0]}-${parts[1]}`;     // regional
+} else {
+    const year = parts[parts.length - 1];
+    validateStr = `proprium-de-sanctis-${year}`;                     // editio typica
+}
+```
+Server resolves via `RomanMissal::getSanctoraleFileName()`.
+
+**Note:** the API's `/missals` endpoint returns `api_path` (URL), NOT `data_path` — do not pass `api_path` directly; always use `sourceDataCheck` with the proper `validate` format.
+
+### Server response shape
+```javascript
+{ "type": "success" | "error", "text": "…", "classes": ".SomeSelector" }
+```
+Server sends selectors with **original casing** but client uses **slugified** card class names. Always pass through `slugifySelector()` from `common.js`:
+
+```javascript
+document.querySelectorAll(slugifySelector(responseData.classes)).forEach(el => { /* update */ });
+```
+
+## API date format
+RFC 3339 datetimes, all-day, UTC: `"2018-05-21T00:00:00+00:00"`. Use `new Date()` + `Intl.DateTimeFormat({ timeZone: 'UTC' })` for display.

--- a/.serena/memories/project_structure.md
+++ b/.serena/memories/project_structure.md
@@ -1,7 +1,7 @@
 # Codebase Structure — UnitTestInterface
 
 ## Top-level layout
-```
+```text
 UnitTestInterface/
 ├── index.php              # Main test runner UI
 ├── admin.php              # Admin interface

--- a/.serena/memories/suggested_commands.md
+++ b/.serena/memories/suggested_commands.md
@@ -1,0 +1,71 @@
+# Suggested Commands — UnitTestInterface
+
+## First-time setup
+```bash
+composer install
+cp .env.example .env.development     # then edit
+# Create credentials.php (gitignored) with HTTP Basic Auth users
+yarn install || npm install || bun install   # for Playwright (bun.lock present)
+```
+
+## Dev server
+```bash
+php -S localhost:3003
+# VSCode: Ctrl+Shift+B → litcal-tests-webui
+```
+Requires running:
+- LiturgicalCalendarAPI on `localhost:8000`
+- WebSocket server (from API repo) on `localhost:8082` (or 8080 — verify `.env.example`)
+
+## Environment
+Copy `.env.example` → `.env.development` (or `.env.local`). Keys:
+- `WS_PROTOCOL`, `WS_HOST`, `WS_PORT`
+- `API_PROTOCOL`, `API_HOST`, `API_PORT`
+- `APP_ENV` (`development` | `production`)
+
+## PHP quality
+```bash
+composer lint            # phpcs (won't fail loud — read output)
+composer lint:fix        # phpcbf
+vendor/bin/phpcs         # raw equivalent
+```
+
+## Markdown
+```bash
+composer lint:md         # markdownlint-cli2 over **/*.md (excl. node_modules, vendor)
+composer lint:md:fix
+```
+
+## Playwright (E2E + screenshots)
+```bash
+npm run playwright:install     # one-time: chromium only
+npm run test                   # all browsers
+npm run test:ci:chromium       # CI mode, chromium only (recommended)
+npm run test:chromium / test:firefox / test:webkit
+npm run test:ui / test:headed
+npm run test:report            # show HTML report
+npm run typecheck              # tsc -p e2e/tsconfig.json --noEmit
+
+# Screenshot helpers
+npm run screenshot
+npm run screenshot:mobile      # 375x667
+npm run screenshot:tablet      # 768x1024
+npm run screenshot:desktop     # 1920x1080
+```
+
+## Running the WebSocket server (from API repo, separately)
+```bash
+# In LiturgicalCalendarAPI repo:
+composer ws:start
+composer ws:stop
+# Or VSCode task: litcal-tests-websockets
+```
+
+## Code review / push discipline
+- CodeRabbit rate-limits PRs:
+  1. Collect ALL CodeRabbit comments first
+  2. Batch fixes into a series of local commits
+  3. Push only after everything is addressed — avoid many small pushes
+
+## System utilities (Linux/WSL2)
+GNU coreutils. Prefer Serena's `find_file`, `search_for_pattern`, `find_symbol` over shell `find`/`grep` inside the repo.

--- a/.serena/memories/task_completion_checklist.md
+++ b/.serena/memories/task_completion_checklist.md
@@ -1,0 +1,59 @@
+# When a Coding Task Is Complete — UnitTestInterface
+
+Run before declaring done / committing:
+
+1. **PHP lint**
+   ```bash
+   composer lint:fix      # phpcbf (auto-fix)
+   composer lint          # phpcs verification (echoes hint, doesn't fail loud)
+   # or raw:
+   vendor/bin/phpcs
+   ```
+
+2. **Markdown**
+   ```bash
+   composer lint:md
+   composer lint:md:fix
+   ```
+
+3. **Type check (Playwright/e2e)**
+   ```bash
+   npm run typecheck      # tsc -p e2e/tsconfig.json --noEmit
+   ```
+
+4. **Playwright tests**
+   ```bash
+   npm run test:ci:chromium
+   ```
+
+5. **Manual UI smoke test (rule from system prompt)** — actually exercise the UI end-to-end:
+   ```bash
+   # In API repo: composer start  AND  composer ws:start
+   # In this repo:
+   php -S localhost:3003
+   # browse to http://localhost:3003 — verify WebSocket connects + tests stream
+   ```
+   For UI changes, capture a quick screenshot to confirm layout:
+   ```bash
+   npm run screenshot:desktop
+   ```
+
+## CI
+GitHub Actions workflow `.github/workflows/main.yml` runs quality checks on push.
+
+## Push discipline (CodeRabbit rate-limit aware)
+- Batch fixes locally; **don't push after every commit**.
+- Workflow:
+  1. Collect ALL CodeRabbit comments
+  2. Address in a series of local commits
+  3. Push the batch once everything is resolved
+
+## When changing WebSocket message handling
+- Verify `category: "sourceDataCheck"` is used for all source data validations
+- Verify `validate` strings follow the `wider-region-…` / `national-calendar-…` / `diocesan-calendar-…` / `proprium-de-sanctis-…` patterns
+- For missal IDs, exercise BOTH regional (`IT_1983`) and editio typica (`EDITIO_TYPICA_1970`) conversion paths
+- Always pass server-supplied `classes` through `slugifySelector()` before DOM queries
+
+## When changing date/time display
+- Confirm `Intl.DateTimeFormat` uses `timeZone: 'UTC'` (events come back as midnight UTC)
+- Confirm `Europe/Vatican` is preserved in any liturgical calculations

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -1,0 +1,154 @@
+# the name by which the project can be referenced within Serena
+project_name: "UnitTestInterface"
+
+
+# list of languages for which language servers are started; choose from:
+#   al                  bash                clojure             cpp                 csharp
+#   csharp_omnisharp    dart                elixir              elm                 erlang
+#   fortran             fsharp              go                  groovy              haskell
+#   haxe                java                julia               kotlin              lua
+#   markdown
+#   matlab              nix                 pascal              perl                php
+#   php_phpactor        powershell          python              python_jedi         r
+#   rego                ruby                ruby_solargraph     rust                scala
+#   swift               terraform           toml                typescript          typescript_vts
+#   vue                 yaml                zig
+#   (This list may be outdated. For the current list, see values of Language enum here:
+#   https://github.com/oraios/serena/blob/main/src/solidlsp/ls_config.py
+#   For some languages, there are alternative language servers, e.g. csharp_omnisharp, ruby_solargraph.)
+# Note:
+#   - For C, use cpp
+#   - For JavaScript, use typescript
+#   - For Free Pascal/Lazarus, use pascal
+# Special requirements:
+#   Some languages require additional setup/installations.
+#   See here for details: https://oraios.github.io/serena/01-about/020_programming-languages.html#language-servers
+# When using multiple languages, the first language server that supports a given file will be used for that file.
+# The first language is the default language and the respective language server will be used as a fallback.
+# Note that when using the JetBrains backend, language servers are not used and this list is correspondingly ignored.
+languages:
+- php
+
+# the encoding used by text files in the project
+# For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
+encoding: "utf-8"
+
+# line ending convention to use when writing source files.
+# Possible values: unset (use global setting), "lf", "crlf", or "native" (platform default)
+# This does not affect Serena's own files (e.g. memories and configuration files), which always use native line endings.
+line_ending:
+
+# The language backend to use for this project.
+# If not set, the global setting from serena_config.yml is used.
+# Valid values: LSP, JetBrains
+# Note: the backend is fixed at startup. If a project with a different backend
+# is activated post-init, an error will be returned.
+language_backend:
+
+# whether to use project's .gitignore files to ignore files
+ignore_all_files_in_gitignore: true
+
+# advanced configuration option allowing to configure language server-specific options.
+# Maps the language key to the options.
+# Have a look at the docstring of the constructors of the LS implementations within solidlsp (e.g., for C# or PHP) to see which options are available.
+# No documentation on options means no options are available.
+ls_specific_settings: {}
+
+# list of additional paths to ignore in this project.
+# Same syntax as gitignore, so you can use * and **.
+# Note: global ignored_paths from serena_config.yml are also applied additively.
+ignored_paths: []
+
+# whether the project is in read-only mode
+# If set to true, all editing tools will be disabled and attempts to use them will result in an error
+# Added on 2025-04-18
+read_only: false
+
+# list of tool names to exclude.
+# This extends the existing exclusions (e.g. from the global configuration)
+#
+# Below is the complete list of tools for convenience.
+# To make sure you have the latest list of tools, and to view their descriptions, 
+# execute `uv run scripts/print_tool_overview.py`.
+#
+#  * `activate_project`: Activates a project based on the project name or path.
+#  * `check_onboarding_performed`: Checks whether project onboarding was already performed.
+#  * `create_text_file`: Creates/overwrites a file in the project directory.
+#  * `delete_memory`: Delete a memory file. Should only happen if a user asks for it explicitly,
+#       for example by saying that the information retrieved from a memory file is no longer correct
+#       or no longer relevant for the project.
+#  * `edit_memory`: Replaces content matching a regular expression in a memory.
+#  * `execute_shell_command`: Executes a shell command.
+#  * `find_file`: Finds files in the given relative paths
+#  * `find_referencing_symbols`: Finds symbols that reference the given symbol using the language server backend
+#  * `find_symbol`: Performs a global (or local) search using the language server backend.
+#  * `get_current_config`: Prints the current configuration of the agent, including the active and available projects, tools, contexts, and modes.
+#  * `get_symbols_overview`: Gets an overview of the top-level symbols defined in a given file.
+#  * `initial_instructions`: Provides instructions Serena usage (i.e. the 'Serena Instructions Manual')
+#       for clients that do not read the initial instructions when the MCP server is connected.
+#  * `insert_after_symbol`: Inserts content after the end of the definition of a given symbol.
+#  * `insert_before_symbol`: Inserts content before the beginning of the definition of a given symbol.
+#  * `list_dir`: Lists files and directories in the given directory (optionally with recursion).
+#  * `list_memories`: List available memories. Any memory can be read using the `read_memory` tool.
+#  * `onboarding`: Performs onboarding (identifying the project structure and essential tasks, e.g. for testing or building).
+#  * `read_file`: Reads a file within the project directory.
+#  * `read_memory`: Read the content of a memory file. This tool should only be used if the information
+#       is relevant to the current task. You can infer whether the information
+#       is relevant from the memory file name.
+#       You should not read the same memory file multiple times in the same conversation.
+#  * `rename_memory`: Renames or moves a memory. Moving between project and global scope is supported
+#       (e.g., renaming "global/foo" to "bar" moves it from global to project scope).
+#  * `rename_symbol`: Renames a symbol throughout the codebase using language server refactoring capabilities.
+#       For JB, we use a separate tool.
+#  * `replace_content`: Replaces content in a file (optionally using regular expressions).
+#  * `replace_symbol_body`: Replaces the full definition of a symbol using the language server backend.
+#  * `safe_delete_symbol`:
+#  * `search_for_pattern`: Performs a search for a pattern in the project.
+#  * `write_memory`: Write some information (utf-8-encoded) about this project that can be useful for future tasks to a memory in md format.
+#       The memory name should be meaningful.
+excluded_tools: []
+
+# list of tools to include that would otherwise be disabled (particularly optional tools that are disabled by default).
+# This extends the existing inclusions (e.g. from the global configuration).
+included_optional_tools: []
+
+# fixed set of tools to use as the base tool set (if non-empty), replacing Serena's default set of tools.
+# This cannot be combined with non-empty excluded_tools or included_optional_tools.
+fixed_tools: []
+
+# list of mode names to that are always to be included in the set of active modes
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the base_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this setting overrides the global configuration.
+# Set this to [] to disable base modes for this project.
+# Set this to a list of mode names to always include the respective modes for this project.
+base_modes:
+
+# list of mode names that are to be activated by default.
+# The full set of modes to be activated is base_modes + default_modes.
+# If the setting is undefined, the default_modes from the global configuration (serena_config.yml) apply.
+# Otherwise, this overrides the setting from the global configuration (serena_config.yml).
+# This setting can, in turn, be overridden by CLI parameters (--mode).
+default_modes:
+
+# initial prompt for the project. It will always be given to the LLM upon activating the project
+# (contrary to the memories, which are loaded on demand).
+initial_prompt: ""
+
+# time budget (seconds) per tool call for the retrieval of additional symbol information
+# such as docstrings or parameter information.
+# This overrides the corresponding setting in the global configuration; see the documentation there.
+# If null or missing, use the setting from the global configuration.
+symbol_info_budget:
+
+# list of regex patterns which, when matched, mark a memory entry as read‑only.
+# Extends the list from the global configuration, merging the two lists.
+read_only_memory_patterns: []
+
+# list of regex patterns for memories to completely ignore.
+# Matching memories will not appear in list_memories or activate_project output
+# and cannot be accessed via read_memory or write_memory.
+# To access ignored memory files, use the read_file tool on the raw file path.
+# Extends the list from the global configuration, merging the two lists.
+# Example: ["_archive/.*", "_episodes/.*"]
+ignored_memory_patterns: []

--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -133,8 +133,11 @@ default_modes:
 
 # initial prompt for the project. It will always be given to the LLM upon activating the project
 # (contrary to the memories, which are loaded on demand).
-initial_prompt: ""
-
+initial_prompt: |
+  - For source-data WebSocket validation, `category` MUST be `"sourceDataCheck"` — NOT `nationalcalendar` / `widerregioncalendar` / `diocesancalendar`. The server regex-transforms `validate` strings (`wider-region-X`, `national-calendar-X`, `diocesan-calendar-X`, `proprium-de-sanctis-X`) into file paths.
+  - Always pipe server-supplied `classes` selectors through `slugifySelector()` from `common.js` before DOM queries (server emits original casing; client uses slugified card class names).
+  - Bootstrap 5 native JS API. No jQuery despite older README mention.
+  - Liturgical timezone always `Europe/Vatican`.
 # time budget (seconds) per tool call for the retrieval of additional symbol information
 # such as docstrings or parameter information.
 # This overrides the corresponding setting in the global configuration; see the documentation there.


### PR DESCRIPTION
## Summary

- Commit Serena MCP memory files generated by onboarding
- Add `.worktrees/` to `.gitignore` (project-local git worktrees convention)

## Why

Serena's `.serena/memories/*.md` files capture project-specific knowledge — overview, structure, suggested commands, code style, and a task-completion checklist — that Serena writes during onboarding. Committing these means:

- Fresh checkouts and new worktrees activate the project with full context immediately
- Teammates using Serena MCP share the same baseline knowledge
- No per-machine, per-branch re-onboarding overhead

## Files

- `.serena/memories/project_overview.md`
- `.serena/memories/project_structure.md`
- `.serena/memories/suggested_commands.md`
- `.serena/memories/code_style_and_conventions.md`
- `.serena/memories/task_completion_checklist.md`

Serena's inner `.serena/.gitignore` (already present in the .serena directory and not part of this PR) excludes `cache/` and `project.local.yml` automatically, so transient state never gets committed.

## Test plan

- [ ] CI is green
- [ ] `git status` shows clean tree after merge (no untracked `.serena/` paths showing as needing commit)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive memory documents covering project overview, structure, coding conventions, recommended development commands, and task completion workflows.

* **Chores**
  * Updated gitignore to exclude local Git worktree directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->