### PR TITLE
Fix docker-stack UI: server-side API routing and empty API version badge

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -89,6 +89,13 @@ if ($apiVersion === '') {
     $apiVersion = 'dev';
 }
 $baseUrl    = $isLocalhost ? "$schema://$host:$port" : "$schema://$host/api/$apiVersion";
+// Server-side (PHP -> API) requests may need a different URL than the browser-facing
+// $baseUrl: in the docker stack the API is reachable from this container only via the
+// docker network (http://litcal-api:8000), while the browser reaches it via the
+// host-published port. Mirrors the API_INTERNAL_URL pattern used by LiturgicalCalendarFrontend.
+$internalBaseUrl = ( isset($_ENV['API_INTERNAL_URL']) && $_ENV['API_INTERNAL_URL'] !== '' )
+    ? rtrim($_ENV['API_INTERNAL_URL'], '/')
+    : $baseUrl;
 
 // Create PSR-compliant HTTP client
 $apiClient = new ApiClient(null, 10, 5, $logger);
@@ -100,7 +107,7 @@ $i18n = new I18n();
 
 // Fetch tests data from API
 try {
-    $testsData   = $apiClient->fetchJsonWithKey("$baseUrl/tests", 'litcal_tests');
+    $testsData   = $apiClient->fetchJsonWithKey("$internalBaseUrl/tests", 'litcal_tests');
     $LitCalTests = $testsData['litcal_tests'];
 } catch (RuntimeException $e) {
     $logger->error('Failed to fetch tests data', ['error' => $e->getMessage()]);
@@ -111,7 +118,7 @@ try {
 }
 
 // Fetch events data from API with locale (before HTML output for consistent error pages)
-$eventsEndpoint = "$baseUrl/events";
+$eventsEndpoint = "$internalBaseUrl/events";
 $apiClient->setLocale($i18n->locale);
 try {
     $eventsData = $apiClient->fetchJsonWithKey($eventsEndpoint, 'litcal_events');
@@ -159,7 +166,7 @@ include_once 'layout/sidebar.php';
                 <div class="row justify-content-center align-items-start">
                     <div class="form-group col col-md-3 border border-top-0 border-bottom-0 border-end-0 border-secondary">
                         <?php
-                            $options = ['locale' => $i18n->locale, 'url' => $baseUrl];
+                            $options = ['locale' => $i18n->locale, 'url' => $internalBaseUrl];
                             $CalendarSelect = new CalendarSelect($options)
                                                     ->class('form-select')
                                                     ->id('APICalendarSelect')

--- a/admin.php
+++ b/admin.php
@@ -5,6 +5,7 @@ ini_set('date.timezone', 'Europe/Vatican');
 
 require_once 'vendor/autoload.php';
 
+use LiturgicalCalendar\Components\ApiClient as ComponentsApiClient;
 use LiturgicalCalendar\Components\CalendarSelect;
 use LiturgicalCalendar\Components\CalendarSelect\OptionsType;
 use LiturgicalCalendar\UnitTestInterface\ApiClient;
@@ -97,6 +98,14 @@ $internalBaseUrl = ( isset($_ENV['API_INTERNAL_URL']) && $_ENV['API_INTERNAL_URL
     ? rtrim($_ENV['API_INTERNAL_URL'], '/')
     : $baseUrl;
 
+// Bootstrap the components library's ApiClient singleton with the server-side API URL
+// BEFORE any component (CalendarSelect) is constructed. Without this, the library
+// auto-initializes its MetadataProvider against the public production API
+// (litcal.johnromanodorazio.com) — the CalendarSelect 'url' option does not exist in v3,
+// so metadata was silently fetched from the public host, hanging the page whenever that
+// host is unreachable.
+ComponentsApiClient::getInstance(['apiUrl' => $internalBaseUrl, 'logger' => $logger]);
+
 // Create PSR-compliant HTTP client
 $apiClient = new ApiClient(null, 10, 5, $logger);
 
@@ -166,7 +175,9 @@ include_once 'layout/sidebar.php';
                 <div class="row justify-content-center align-items-start">
                     <div class="form-group col col-md-3 border border-top-0 border-bottom-0 border-end-0 border-secondary">
                         <?php
-                            $options = ['locale' => $i18n->locale, 'url' => $internalBaseUrl];
+                            // NOTE: metadata URL comes from the ComponentsApiClient singleton
+                            // bootstrapped above — CalendarSelect v3 has no 'url' option.
+                            $options = ['locale' => $i18n->locale];
                             $CalendarSelect = new CalendarSelect($options)
                                                     ->class('form-select')
                                                     ->id('APICalendarSelect')

--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -26,6 +26,14 @@ test.describe('Admin Page - Unauthenticated State', () => {
         expect(isLoginVisible).toBe(true);
     });
 
+    test('should derive a non-empty API version badge when API_BASE_PATH is empty', async ({ adminPage, page }) => {
+        await adminPage.goToAdmin();
+
+        // With an empty (or unset) API_BASE_PATH, the navbar badge must fall
+        // back to 'dev' rather than rendering an empty badge.
+        await expect(page.locator('#apiVersionBadge')).toHaveText('dev');
+    });
+
     test('should have data-requires-auth elements disabled when not logged in', async ({ adminPage, page }) => {
         await adminPage.goToAdmin();
 

--- a/layout/topnavbar.php
+++ b/layout/topnavbar.php
@@ -34,7 +34,9 @@
                         <i class="fas fa-code-branch me-1"></i><span class="d-lg-none d-xl-inline"><?php echo _("API Version"); ?></span>
                     </span>
                     <span class="badge bg-secondary" id="apiVersionBadge"><?php
-                        $navApiBasePath = $_ENV['API_BASE_PATH'] ?? '/api/dev';
+                        // Treat an empty API_BASE_PATH (root-mounted local API) the same as unset:
+                        // fall back to '/api/dev' so the badge never renders empty.
+                        $navApiBasePath = ( isset($_ENV['API_BASE_PATH']) && $_ENV['API_BASE_PATH'] !== '' ) ? $_ENV['API_BASE_PATH'] : '/api/dev';
                         $navTrimmedPath = trim($navApiBasePath, '/');
                         $navApiVersion = preg_match('#^api/(.+)$#', $navTrimmedPath, $m) ? $m[1] : $navTrimmedPath;
                         echo htmlspecialchars($navApiVersion);


### PR DESCRIPTION
Stacked on #32 (base: `feature/30-persist-test-run-results`) — merge after it.

Two small fixes surfaced while exercising the UI from the docker stack (`litcal-tests` container on port 3003):

## 1. `admin.php` server-side API calls failed with cURL error 7

Inside the container, `localhost` resolves to the container's own loopback (the `extra_hosts: host-gateway` entry loses to the built-in `127.0.0.1 localhost` line), so PHP-side Guzzle requests to `http://localhost:8000` could never connect. The browser side was unaffected since the browser resolves `localhost` on the host.

Server-side consumers (`/tests` fetch, `/events` fetch, `CalendarSelect` component) now use an optional **`API_INTERNAL_URL`** env var, falling back to the browser-facing base URL when unset — the same pattern LiturgicalCalendarFrontend already uses for its PHP→API calls. `window.baseUrl` (client-side) is unchanged.

## 2. Empty API Version badge / `admin.php?apiVersion=`

`layout/topnavbar.php` used `$_ENV['API_BASE_PATH'] ?? '/api/dev'`, which doesn't catch the **empty-string** value that local setups (root-mounted API, `API_BASE_PATH=`) provide — rendering an empty badge and an empty `apiVersion` query param on the admin link. Empty is now treated the same as unset.

## Test plan

- New e2e assertion (`admin.spec.ts`): `#apiVersionBadge` must render `dev` when `API_BASE_PATH` is empty — verified RED before the fix, GREEN after
- `API_INTERNAL_URL` verified live in the docker stack: admin.php renders tests/events/calendar-select with `API_INTERNAL_URL=http://litcal-api:8000`; unset locally, behavior is identical to before
- `vendor/bin/phpcs` clean (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)