### PR TITLE
Fall back to /api/dev when API_BASE_PATH is empty in navbar badge

### DIFF
--- a/e2e/admin.spec.ts
+++ b/e2e/admin.spec.ts
@@ -26,6 +26,14 @@ test.describe('Admin Page - Unauthenticated State', () => {
         expect(isLoginVisible).toBe(true);
     });
 
+    test('should derive a non-empty API version badge when API_BASE_PATH is empty', async ({ adminPage, page }) => {
+        await adminPage.goToAdmin();
+
+        // With an empty (or unset) API_BASE_PATH, the navbar badge must fall
+        // back to 'dev' rather than rendering an empty badge.
+        await expect(page.locator('#apiVersionBadge')).toHaveText('dev');
+    });
+
     test('should have data-requires-auth elements disabled when not logged in', async ({ adminPage, page }) => {
         await adminPage.goToAdmin();
 

--- a/layout/topnavbar.php
+++ b/layout/topnavbar.php
@@ -34,7 +34,9 @@
                         <i class="fas fa-code-branch me-1"></i><span class="d-lg-none d-xl-inline"><?php echo _("API Version"); ?></span>
                     </span>
                     <span class="badge bg-secondary" id="apiVersionBadge"><?php
-                        $navApiBasePath = $_ENV['API_BASE_PATH'] ?? '/api/dev';
+                        // Treat an empty API_BASE_PATH (root-mounted local API) the same as unset:
+                        // fall back to '/api/dev' so the badge never renders empty.
+                        $navApiBasePath = ( isset($_ENV['API_BASE_PATH']) && $_ENV['API_BASE_PATH'] !== '' ) ? $_ENV['API_BASE_PATH'] : '/api/dev';
                         $navTrimmedPath = trim($navApiBasePath, '/');
                         $navApiVersion = preg_match('#^api/(.+)$#', $navTrimmedPath, $m) ? $m[1] : $navTrimmedPath;
                         echo htmlspecialchars($navApiVersion);


### PR DESCRIPTION
Replaces #33 (auto-closed when its stacked base branch was deleted by the #32 merge; closed PRs cannot be retargeted).

Two of #33's three commits (API_INTERNAL_URL support and the CalendarSelect metadata bootstrap) were cherry-picked into #32 and are already on `main`. This PR carries the one remaining fix:

`layout/topnavbar.php` used `$_ENV['API_BASE_PATH'] ?? '/api/dev'`, which doesn't catch the **empty-string** value local setups provide (root-mounted API, `API_BASE_PATH=`) — rendering an empty API Version badge and an empty `apiVersion` query param on the admin link. Empty is now treated the same as unset.

## Test plan

- New e2e assertion (`admin.spec.ts`): `#apiVersionBadge` must render `dev` when `API_BASE_PATH` is empty — RED before the fix, GREEN after
- admin.spec.ts: 13 passed on the rebuilt branch

🤖 Generated with [Claude Code](https://claude.com/claude-code)