### PR TITLE
CI: extract gettext strings from all tracked PHP files

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -7,7 +7,9 @@ on:
   # Triggers the workflow on push or pull request events but only for the given branch
   push:
     branches: [ main ]
-    paths: [ '**.php' ]
+    # Also run when this workflow itself changes, so extraction fixes take
+    # effect immediately instead of waiting for the next .php change.
+    paths: [ '**.php', '.github/workflows/main.yml' ]
 
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
@@ -28,7 +30,10 @@ jobs:
         id: update_pot
         run: |
           sudo apt-get install -y gettext
-          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" -o i18n/litcal.pot index.php admin.php layout/topnavbar.php layout/sidebar.php components/NewTestModal.php
+          # Extract from every tracked PHP file — a hardcoded list silently drops
+          # new files (resources.php and components/login-modal.php were missed
+          # for months, hiding 19 msgids from translators).
+          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" -o i18n/litcal.pot $(git ls-files '*.php')
           echo "POT_LINES_CHANGED=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev '^[+-]"POT-Creation-Date' | wc -l)" >> $GITHUB_OUTPUT
 
       # push the output folder to your repo

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -32,8 +32,9 @@ jobs:
           sudo apt-get install -y gettext
           # Extract from every tracked PHP file — a hardcoded list silently drops
           # new files (resources.php and components/login-modal.php were missed
-          # for months, hiding 19 msgids from translators).
-          xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" -o i18n/litcal.pot $(git ls-files '*.php')
+          # for months, hiding 19 msgids from translators). Null-delimited so
+          # paths containing spaces or other IFS characters cannot word-split.
+          git ls-files -z '*.php' | xargs -0 xgettext --from-code=UTF-8 --add-comments='translators:' --keyword="pgettext:1c,2" -o i18n/litcal.pot
           echo "POT_LINES_CHANGED=$(git diff -U0 | grep '^[+|-][^+|-]' | grep -Ev '^[+-]"POT-Creation-Date' | wc -l)" >> $GITHUB_OUTPUT
 
       # push the output folder to your repo


### PR DESCRIPTION
The `xgettext` command in the POT-regeneration workflow used a hardcoded file list, which silently omitted `resources.php` and `components/login-modal.php` — hiding **19 msgids** (the entire login modal plus the Resources-page strings like "API Paths" / "Source data") from `i18n/litcal.pot`, and therefore from translators.

## Changes

- Derive the extraction file list from `git ls-files '*.php'` so newly added files are picked up automatically — a hardcoded list is exactly how this gap opened
- Add `.github/workflows/main.yml` itself to the push `paths` filter, so merging this PR (or any future extraction fix) regenerates the `.pot` immediately instead of waiting for the next `.php` change

## Verification

Ran both commands locally against the current tree:

| Command | msgids extracted |
|---|---|
| old (hardcoded list) | 76 |
| new (`git ls-files '*.php'`) | 95 |

Newly captured strings include the full login modal ("Administrator Login", "Password", "Login failed. Please check your credentials.", …) and Resources-page labels. YAML validated.

The `.po` catalogs are left untouched — merging the new msgids into the per-locale catalogs is the Weblate/msgmerge flow's job once the regenerated `.pot` lands on main (which happens automatically on merge thanks to the paths addition).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved translation template updates so all tracked PHP files are included, helping keep localized text more complete.
  * Updated the update workflow to run when workflow configuration changes, reducing the chance of missed translation refreshes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->