### PR TITLE
refactor: merge variableCorrespondence test type into exactCorrespondence

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -195,7 +195,7 @@ include_once 'layout/sidebar.php';
                             <button type="button" class="btn btn-primary col col-md-3 <?php echo $isAuthenticated ? '' : 'd-none'; ?>" data-requires-auth
                                 data-testtype="exactCorrespondence" data-bs-toggle="modal" data-bs-target="#modalDefineTest"
                                 title="<?php
-                                    echo _("In the span of years for which we are making an assertion, we assert that the liturgical event should exist, and should fall on an expected date (date can optionally be defined differently for each given year)");
+                                    echo _("Each assertion independently defines the expectation for its year: in the span of years for which we are making an assertion, we assert that the liturgical event should exist and should fall on an expected date (date can optionally be defined differently for each given year), or that it should not exist for given years.");
                                 ?>">
                                 <small><b><i class="fas fa-vial me-2"></i> <?php echo _("Exact date"); ?></b></small>
                             </button>
@@ -212,13 +212,6 @@ include_once 'layout/sidebar.php';
                                     echo _("When a liturgical event should no longer exist after a certain year, we assert that for a certain span of years before such year the liturgical event should fall on an expected date (date can optionally be defined differently for each given year), while for a certain span of years after such year the liturgical event should not exist.");
                                 ?>">
                                 <small><b><?php echo _("Exact date until year"); ?> <i class="fas fa-right-to-bracket ms-2"></i></b></small>
-                            </button>
-                            <button type="button" class="btn btn-primary col col-md-4 <?php echo $isAuthenticated ? '' : 'd-none'; ?>" data-requires-auth
-                                data-testtype="variableCorrespondence" data-bs-toggle="modal" data-bs-target="#modalDefineTest"
-                                title="<?php
-                                    echo _("When a liturgical event is expected to be overridden in various years for whatever reason, we assert that it should exist in certain given years on an expected date (date can optionally be defined differently for each given year), and that it should not exist for other given years.");
-                                ?>">
-                                <small><b><i class="fas fa-square-root-variable me-2"></i> <?php echo _("Variable existence by year"); ?></b></small>
                             </button>
                         </div>
                         <div class="alert alert-info mb-0 <?php echo $isAuthenticated ? 'd-none' : ''; ?>" role="alert" data-requires-no-auth>

--- a/assets/js/AssertionsBuilder.js
+++ b/assets/js/AssertionsBuilder.js
@@ -12,8 +12,7 @@
 export const TestType = Object.freeze({
     ExactCorrespondence:        'exactCorrespondence',
     ExactCorrespondenceSince:   'exactCorrespondenceSince',
-    ExactCorrespondenceUntil:   'exactCorrespondenceUntil',
-    VariableCorrespondence:     'variableCorrespondence'
+    ExactCorrespondenceUntil:   'exactCorrespondenceUntil'
 });
 
 /**

--- a/assets/js/admin.js
+++ b/assets/js/admin.js
@@ -246,7 +246,7 @@ const sanitizeOnSetValue = {
                 value = (target['event_key']) + 'Test';
                 break;
             case 'test_type':
-                if( false === [TestType.ExactCorrespondence, TestType.ExactCorrespondenceSince, TestType.ExactCorrespondenceUntil, TestType.VariableCorrespondence ].includes( value ) ) {
+                if( false === [TestType.ExactCorrespondence, TestType.ExactCorrespondenceSince, TestType.ExactCorrespondenceUntil ].includes( value ) ) {
                     console.warn(`property ${prop} of this object must have a valid TestType value`);
                     return;
                 }
@@ -920,8 +920,7 @@ let isotopeYearsToTestGrid = null;
 const modalLabel = {
     exactCorrespondence: 'Exact Date Correspondence Test',
     exactCorrespondenceSince: 'Exact Date Correspondence Since Year Test',
-    exactCorrespondenceUntil: 'Exact Date Correspondence Until Year Test',
-    variableCorrespondence: 'Variable Existence Test'
+    exactCorrespondenceUntil: 'Exact Date Correspondence Until Year Test'
 }
 
 const ArrayRange = (start, end, endInclusive) => Array.from({length: (end - start)+endInclusive}, (v, k) => k + start);
@@ -944,7 +943,7 @@ document.querySelector('#modalDefineTest').addEventListener('show.bs.modal', ev 
     }
     document.querySelector('#yearsToTestGrid').innerHTML = '';
     const removeIcon = '<i class="fas fa-circle-xmark ms-1 opacity-50" aria-hidden="true" role="button" title="remove"></i>';
-    const hammerIcon = currentTestType === TestType.ExactCorrespondence ? '' : '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
+    const hammerIcon = '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
     let htmlStr = '';
     let years;
     let minYear = 1970;
@@ -1016,8 +1015,8 @@ document.querySelector('#modalDefineTest').addEventListener('show.bs.modal', ev 
                 document.querySelector('#yearSinceUntilShadow').value = pivotYear;
             }
         }
-        // Apply visual indication for Variable Existence tests
-        if (currentTestType === TestType.VariableCorrespondence && proxiedTest.assertions) {
+        // Apply visual indication for the years marked as non-existing in an Exact Correspondence test
+        if (currentTestType === TestType.ExactCorrespondence && proxiedTest.assertions) {
             proxiedTest.assertions.forEach(assertion => {
                 if (assertion.assert === AssertType.EventNotExists) {
                     const yearSpan = document.querySelector(`#yearsToTestGrid .testYearSpan.year-${assertion.year}`);
@@ -1116,7 +1115,7 @@ document.addEventListener('change', ev => {
     isotopeYearsToTestGrid?.destroy();
     document.querySelector('#yearsToTestGrid').innerHTML = '';
     const removeIcon = '<i class="fas fa-circle-xmark ms-1 opacity-50" aria-hidden="true" role="button" title="remove"></i>';
-    const hammerIcon = currentTestType === TestType.ExactCorrespondence ? '' : '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
+    const hammerIcon = '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
     const currentEventKey = document.querySelector('#existingLitEventName').value;
     const existingOption = document.querySelector(`#existingLitEventsList option[value="${escapeSelector(currentEventKey)}"]`);
     let htmlStr = '';
@@ -1164,7 +1163,7 @@ document.addEventListener('click', ev => {
 
     // Generate icons
     const removeIcon = '<i class="fas fa-circle-xmark ms-1 opacity-50" aria-hidden="true" role="button" title="remove"></i>';
-    const hammerIcon = currentTestType === TestType.ExactCorrespondence ? '' : '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
+    const hammerIcon = '<i class="fas fa-hammer me-1 opacity-50" aria-hidden="true" role="button" title="set year"></i>';
 
     // Reinstate the span
     deletedSpan.classList.remove('deleted');
@@ -1184,7 +1183,7 @@ document.addEventListener('click', ev => {
 
     const parentEl      = hammerIcon.parentElement;
     const grandParentEl = parentEl.parentElement;
-    const bgClass       = currentTestType === TestType.VariableCorrespondence ? 'bg-warning' : 'bg-info';
+    const bgClass       = currentTestType === TestType.ExactCorrespondence ? 'bg-warning' : 'bg-info';
     if ([TestType.ExactCorrespondenceSince, TestType.ExactCorrespondenceUntil].includes(currentTestType)) {
         grandParentEl.querySelectorAll('.testYearSpan').forEach(el => {
             el.classList.remove('bg-info', 'bg-warning');

--- a/components/NewTestModal.php
+++ b/components/NewTestModal.php
@@ -60,7 +60,7 @@
                                                         . 'by clicking on the hammer icon inside one of the years in the range.'
                                                     );
                                                     ?> </small>
-                                                <small class="variableCorrespondence d-none"> <?php
+                                                <small class="exactCorrespondence d-none"> <?php
                                                     echo _(
                                                         'Finally, set the years in which the liturgical event shouldn\'t exist '
                                                         . 'by clicking on the hammer icon inside the years in the range.'
@@ -89,9 +89,6 @@
                                     ?></div>
                                     <div class="invalid-feedback exactCorrespondenceUntil d-none"><?php
                                         echo _("Please set the year until which the liturgical event should exist.");
-                                    ?></div>
-                                    <div class="invalid-feedback variableCorrespondence d-none"><?php
-                                        echo _("Please set the years in which the liturgical event should not exist.");
                                     ?></div>
                                 </div>
                             </div>


### PR DESCRIPTION
Closes #36

## Summary

Merges the `variableCorrespondence` test type into `exactCorrespondence`, following Liturgical-Calendar/LiturgicalCalendarAPI#704 / Liturgical-Calendar/LiturgicalCalendarAPI#705. `exactCorrespondence` now carries the merged semantics: each assertion independently defines the expectation for its year, either existence-on-date or non-existence.

## Changes

- `admin.php`: remove the "Variable existence by year" button; the "Exact date" button title now describes the merged semantics
- `assets/js/admin.js`:
  - drop `VariableCorrespondence` from the proxy validation list and the modal label map
  - always show the per-year hammer toggle — `exactCorrespondence` inherits the former `variableCorrespondence` behavior of marking non-existence years (this was the last surviving difference between the two types, a UI-only restriction the schema never enforced)
  - re-key the year-marking logic (edit-mode `bg-warning` restore, hammer-click `bgClass`) to `ExactCorrespondence`
- `assets/js/AssertionsBuilder.js`: drop the `VariableCorrespondence` TestType constant
- `components/NewTestModal.php`: re-key the hammer help text to `exactCorrespondence` (translatable string kept verbatim to preserve existing translations); drop the `variableCorrespondence` invalid-feedback element

## Verification

- `php -l` on both PHP files, `node --check` on both JS files
- `vendor/bin/phpcs` on the changed PHP files: 0 errors (only pre-existing-style long-line warnings on translatable strings)
- No `variableCorrespondence` references remain in the codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)