### PR TITLE
fix(tests): update source-data paths for API rite-partition (lockstep with API #737)

### DIFF
--- a/assets/js/index.js
+++ b/assets/js/index.js
@@ -59,7 +59,7 @@ const ENDPOINTS = {
     MISSALS: ""
 }
 
-const SOURCE_DATA_PATH = "jsondata/sourcedata";
+const SOURCE_DATA_PATH = "jsondata/sourcedata/rite/roman";
 
 /**
  * Array of objects that define the source data checks.

--- a/assets/js/resources.js
+++ b/assets/js/resources.js
@@ -240,22 +240,22 @@ const resourceDataChecks = [
 const sourceDataChecks = [
     {
         "validate": "memorials-from-decrees",
-        "sourceFile": "jsondata/sourcedata/decrees/decrees.json",
+        "sourceFile": "jsondata/sourcedata/rite/roman/decrees/decrees.json",
         "category": "sourceDataCheck"
     },
     {
         "validate": "memorials-from-decrees-i18n",
-        "sourceFolder": "jsondata/sourcedata/decrees/i18n",
+        "sourceFolder": "jsondata/sourcedata/rite/roman/decrees/i18n",
         "category": "sourceDataCheck"
     },
     {
         "validate": "proprium-de-tempore",
-        "sourceFile": "jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json",
+        "sourceFile": "jsondata/sourcedata/rite/roman/missals/propriumdetempore/propriumdetempore.json",
         "category": "sourceDataCheck"
     },
     {
         "validate": "proprium-de-tempore-i18n",
-        "sourceFolder": "jsondata/sourcedata/missals/propriumdetempore/i18n",
+        "sourceFolder": "jsondata/sourcedata/rite/roman/missals/propriumdetempore/i18n",
         "category": "sourceDataCheck"
     }
 ];


### PR DESCRIPTION
## Summary

Lockstep companion to **LiturgicalCalendarAPI PR #737** (rite-partitioned source data).

The API reorganizes its source-data tree so liturgical **rite** is the top-level partition: `jsondata/sourcedata/{decrees,missals,…}` moves under `jsondata/sourcedata/rite/roman/…`. The UnitTestInterface's `sourceDataCheck` validations send **filesystem paths** that the WS health server reads directly from disk, so the pre-migration paths now 404 with:

> There was an error decoding the Data file `jsondata/sourcedata/missals/propriumdetempore/propriumdetempore.json` as JSON: Syntax error.

## Fix

Re-point the 8 hardcoded source-data paths to `rite/roman/`:

- `assets/js/index.js` — `SOURCE_DATA_PATH` → `"jsondata/sourcedata/rite/roman"` (covers the 4 missal `sourceDataChecks`: propriumdetempore + propriumdesanctis 1970/2002/2008).
- `assets/js/resources.js` — 4 literals: `decrees/decrees.json`, `decrees/i18n`, `missals/propriumdetempore/propriumdetempore.json`, `missals/propriumdetempore/i18n`.

Only Roman data is referenced, so all paths move uniformly under `rite/roman/`.

## Verification

Against the running stack with `litcal-api` on the migrated branch, the WS server's file read was reproduced:

- OLD path → `file_get_contents` false (the reported failure).
- NEW path → reads 9378 bytes, `json_decode` OK.

The server-side schema-detection map is keyed by the same new path (via the `MISSALS_FOLDER` constant), so the validations resolve a schema and pass.

## Merge coordination

**Merge together with API #737.** Merging either alone leaves the integrity tests pointing at the wrong tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated Roman-rite resource paths so missal, decree, memorial, and related localization data can be loaded from their new directory locations.
  * Improved validation of these resources by aligning checks with the updated data structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->